### PR TITLE
Fixes for time-series data gaps in metrics

### DIFF
--- a/webawesome/templates/en-us/Chart.htm
+++ b/webawesome/templates/en-us/Chart.htm
@@ -68,40 +68,47 @@
         var labelFormat;
         var labelFormatLong;
         if(yearsApart > 1) {
-          labelFormat = 'YYYY';
-          labelFormatLong = 'YYYY';
+          labelFormat = 'ddd MMM D, YYYY';
+          labelFormatLong = 'ddd MMM D, YYYY';
         } else if(monthsApart > 1) {
-          labelFormat = 'MMM YYYY';
-          labelFormatLong = 'MMM YYYY';
+          labelFormat = 'ddd MMM D, YYYY, h:mm a';
+          labelFormatLong = 'ddd MMM D, YYYY, h:mm a';
         } else if(daysApart > 1) {
-          labelFormat = 'ddd MMM D, h:mm a';
+          labelFormat = 'ddd MMM D, YYYY, h:mm a';
           labelFormatLong = 'ddd MMM D, YYYY, h:mm a';
         } else if(hoursApart > 1) {
-          labelFormat = 'ddd MMM D, h:mm a';
+          labelFormat = 'ddd MMM D, YYYY, h:mm a';
           labelFormatLong = 'ddd MMM D, YYYY, h:mm a';
         } else {
-          labelFormat = 'ddd MMM D, h:mm a';
+          labelFormat = 'ddd MMM D, YYYY, h:mm a';
           labelFormatLong = 'ddd MMM D, YYYY, h:mm a';
         }
         var step;
+        var stepTime;
         switch (facetRangeGapVal) {
           case "+1YEAR":
             step = "1y";
+            stepMillis = 31557600000;
             break;
           case "+1MONTH":
             step = "1M";
+            stepMillis = 2678400000;
             break;
           case "+1DAY":
             step = "1d";
+            stepMillis = 86400000;
             break;
           case "+1HOUR":
             step = "1h";
+            stepMillis = 3600000;
             break;
           case "+1MINUTE":
             step = "1m";
+            stepMillis = 60000;
             break;
           default:
             step = "7d";
+            stepMillis = 604800000;
         }
 
         var timeQuery = {
@@ -110,6 +117,7 @@
           , startDate: startDate
           , endDate: endDate
           , step: step
+          , stepMillis: stepMillis
           , timeZone: timeZone
           , minutesApart: minutesApart
           , hoursApart: hoursApart
@@ -127,7 +135,7 @@
 
 {%- macro dashboardCard(divId, cardTitle, style='--point-radius: 2px; ', min=null, max=null) %}
       <div>
-        <wa-line-chart legend-position="bottom" id="{{ divId | e }}" label="{{ cardTitle | e}}" description="" style="{{ style | e | default('') }}"{% if min is defined %}min="{{ min | e }}"{% endif %}{% if max is defined %}max="{{ max | e }}"{% endif %}>
+        <wa-line-chart legend-position="bottom" id="{{ divId | e }}" label="{{ cardTitle | e}}" description="" style="{{ style | e | default('') }}"{% if min is defined %} min="{{ min | e }}"{% endif %}{% if max is defined %} max="{{ max | e }}"{% endif %}>
         </wa-line-chart>
         <wa-details summary="Prometheus Keycloak Proxy queries">
           <table id="{{ divId | e }}-data-links-table" class="wa-zebra-rows">
@@ -150,7 +158,7 @@
       </div>
 {% endmacro -%}
 
-{%- macro hubClusterProjectDashboardAsyncFunction(divId, yaxisTitle, classSimpleName, legendTitle, resultLabel, metricPrefix, metricMiddle='', metricSuffix='', clusterVar='clusterName', projectPrefixLabel='namespace', projectMiddleLabel=null, projectVar='projectName', tickformat=null, timeZone=null, emptyClusterReplace=null, emptyClusterReplaceWith=null, formatBytes=false, formatPercent=false, xLabelPrefix='', xLabelSuffix='', yLabelPrefix='', yLabelSuffix='', openDetailsSelector=null, datasetLabel=null) %}
+{%- macro hubClusterProjectDashboardAsyncFunction(divId, yaxisTitle, classSimpleName, legendTitle, resultLabel, metricPrefix, metricMiddle='', metricSuffix='', clusterVar='clusterName', modelPrefixLabel='namespace', modelMiddleLabel=null, modelVar='projectName', tickformat=null, timeZone=null, emptyClusterReplace=null, emptyClusterReplaceWith=null, formatBytes=false, formatPercent=false, xLabelPrefix='', xLabelSuffix='', yLabelPrefix='', yLabelSuffix='', openDetailsSelector=null, datasetLabel=null, fill=false, metricLabels=null, displayLabels=null, colors=['blue','pink','green','yellow','purple','orange','indigo','red','cyan','gray']) %}
 
     function {{ jsFunctionName(divId) }}Popover(event) {
       var buttonId = event.target.getAttribute('id');
@@ -170,6 +178,7 @@
       $headerHub.setAttribute('class', 'wa-heading-m ');
       $headerHub.innerText = 'hub: ' + hubId;
       $popoverStack.append($headerHub);
+      {% if classSimpleName != 'Hub' -%}
 
       if(dataMetric.cluster) {
         var $headerCluster = document.createElement('div');
@@ -180,7 +189,7 @@
 
       var $headerProject = document.createElement('div');
       $headerProject.setAttribute('class', 'wa-heading-m ');
-      $headerProject.innerText = 'project: ' + dataMetric.{{ projectPrefixLabel }};
+      $headerProject.innerText = 'project: ' + dataMetric.{{ modelPrefixLabel }};
       $popoverStack.append($headerProject);
       {% if resultLabel is defined -%}
 
@@ -189,6 +198,7 @@
       $headerVar.innerText = '{{ resultLabel }}: ' + dataMetric.{{ resultLabel }};
       $popoverStack.append($headerVar);
       {%- endif %}
+      {% endif -%}
 
       $popoverStack.append(document.createElement('wa-divider'));
 
@@ -269,19 +279,20 @@
         const urls = [];
         const queries = [];
         const hubIds = Object.keys(window.varsFq.hubId.facetField.counts);
-        const clusterNames = Object.keys(window.varsFq.clusterName.facetField.counts);
+        const clusterNames = window.varsFq?.clusterName?.facetField?.counts ? Object.keys(window.varsFq.clusterName.facetField.counts) : [];
         var requestHubIds = [];
         hubIds.forEach((hubId, i) => {
-          var projects = list{{ classSimpleName }}.filter(o => o.hubId === hubId);
-          var uniqueClusterNames = [...new Set(projects.map(item => item.{{ clusterVar }}))];
+          var results = list{{ classSimpleName }}.filter(o => o.hubId === hubId);
+          {% if 'Project' == classSimpleName -%}
+          var uniqueClusterNames = [...new Set(results.map(item => item.{{ clusterVar }}))];
           uniqueClusterNames.forEach(({{ clusterVar }}, i) => {
-            var uniqueProjectNames = [...new Set(projects.filter(project => project.{{ clusterVar }} === {{ clusterVar }}).map(project => project.{{ projectVar }}))];
-            var projectPrefixLabel = (clusterNames.length > 0 ? ('cluster="' + {{ clusterVar }} + '", ') : '') + '{{ projectPrefixLabel }}=~"' + uniqueProjectNames.join('|') + '"';
-            var projectMiddleLabel = (clusterNames.length > 0 ? ('cluster="' + {{ clusterVar }} + '", ') : '') + '{{ projectMiddleLabel if projectMiddleLabel is defined else projectPrefixLabel }}=~"' + uniqueProjectNames.join('|') + '"';
-            var query = '{{ metricPrefix }}' + projectPrefixLabel + {% if metricMiddle != '' %}'{{ metricMiddle }}' + projectMiddleLabel + {% endif %}'{{ metricSuffix }}';
+            var uniqueModelNames = [...new Set(results.filter(result => result.{{ clusterVar }} === {{ clusterVar }}).map(result => result.{{ modelVar }}))];
+            var modelPrefixLabel = (clusterNames.length > 0 ? ('cluster="' + {{ clusterVar }} + '", ') : '') + '{{ modelPrefixLabel }}=~"' + uniqueModelNames.join('|') + '"';
+            var modelMiddleLabel = (clusterNames.length > 0 ? ('cluster="' + {{ clusterVar }} + '", ') : '') + '{{ modelMiddleLabel if modelMiddleLabel is defined else modelPrefixLabel }}=~"' + uniqueModelNames.join('|') + '"';
+            var query = '{{ metricPrefix }}' + modelPrefixLabel + {% if metricMiddle != '' %}'{{ metricMiddle }}' + modelMiddleLabel + {% endif %}'{{ metricSuffix }}';
             {% if emptyClusterReplace is defined -%}
             if(clusterNames.length == 0)
-              query = '{{ metricPrefix | replace(emptyClusterReplace, emptyClusterReplaceWith) }}' + projectPrefixLabel + {% if metricMiddle != '' %}'{{ metricMiddle | replace(emptyClusterReplace, emptyClusterReplaceWith)  }}' + projectMiddleLabel + {% endif %}'{{ metricSuffix | replace(emptyClusterReplace, emptyClusterReplaceWith)  }}';
+              query = '{{ metricPrefix | replace(emptyClusterReplace, emptyClusterReplaceWith) }}' + modelPrefixLabel + {% if metricMiddle != '' %}'{{ metricMiddle | replace(emptyClusterReplace, emptyClusterReplaceWith)  }}' + modelMiddleLabel + {% endif %}'{{ metricSuffix | replace(emptyClusterReplace, emptyClusterReplaceWith)  }}';
             {%- endif -%}
             queries.push(query);
             urls.push('/prom-keycloak-proxy/' + encodeURIComponent(hubId) + '/api/v1/query_range?' + new URLSearchParams(Object.assign({ 
@@ -290,6 +301,16 @@
                 }, timeQuery)).toString());
             requestHubIds.push(hubId);
           });
+          {%- else -%}
+          {% if 'Hub' == classSimpleName -%}
+          var query = '{{ metricPrefix }}' + {% if metricMiddle != '' %}'{{ metricMiddle }}' + {% endif %}'{{ metricSuffix }}';
+          queries.push(query);
+          urls.push('/prom-keycloak-proxy/' + encodeURIComponent(hubId) + '/api/v1/query_range?' + new URLSearchParams(Object.assign({ 
+              query: query
+              }, timeQuery)).toString());
+          requestHubIds.push(hubId);
+          {%- endif -%}
+          {%- endif -%}{{''}}
         });
         const responses = await Promise.all(urls.map(url => fetch(url)));
         const dataPromises = responses.map(response => response.json());
@@ -313,44 +334,46 @@
           $linkTd.append($linkA);
         });
 
+        {% if metricLabels is not defined and displayLabels is not defined -%}
+        metricLabels = ['hub', 'cluster', '{{ modelPrefixLabel }}'];
+        displayLabels = ['hub', 'cluster', 'project'];
+        {% else -%}
+        metricLabels = [{% for metricLabel in metricLabels %}'{{ metricLabel }}',{% endfor %}];
+        displayLabels = [{% for displayLabel in displayLabels %}'{{ displayLabel }}',{% endfor %}];
+        {% endif -%}
         var $theadTr = document.getElementById('{{ divId | e }}-data-thead-tr');
         $theadTr.innerHTML = '';
+        var $theadTrTd;
 
         var $theadTrTd = document.createElement('td');
         $theadTrTd.innerText = '';
         $theadTr.append($theadTrTd);
 
-        var $theadTrTd = document.createElement('td');
-        $theadTrTd.innerText = 'hub';
-        $theadTr.append($theadTrTd);
-
-        if(clusterNames.length > 0) {
-          $theadTrTd = document.createElement('td');
-          $theadTrTd.innerText = 'cluster';
-          $theadTr.append($theadTrTd);
-        }
-
-        $theadTrTd = document.createElement('td');
-        $theadTrTd.innerText = 'project';
-        $theadTr.append($theadTrTd);
-        {% if resultLabel is defined -%}
+        displayLabels.forEach((displayLabel, i) => {
+          if(displayLabel == 'cluster' && clusterNames.length > 0 || displayLabel != 'cluster') {
+            $theadTrTd = document.createElement('td');
+            $theadTrTd.innerText = displayLabel;
+            $theadTr.append($theadTrTd);
+          }
+        });
 
         $theadTrTd = document.createElement('td');
         $theadTrTd.innerText = '{{ resultLabel | e }}';
         $theadTr.append($theadTrTd);
-        {%- endif %}
 
         $theadTrTd = document.createElement('td');
         $theadTrTd.innerText = '{{ cardTitle | e }}';
         $theadTr.append($theadTrTd);
 
         var $tbody = document.getElementById('{{ divId | e }}-data-tbody');
+        const range = [];
+        let current = new Date(timeQuery.startDate);
+        while (current <= timeQuery.endDate) {
+          range.push(current);
+          labels.push(moment.tz(current, timeQuery.timeZone).format(timeQuery.labelFormat));
+          current = new Date(current.getTime() + timeQuery.stepMillis);
+        }
         responseJsons.forEach((responseJson, i) => {
-          if(labels.length == 0 && responseJson.data.result.length > 0) {
-            responseJson.data.result[0].values.map(values => {
-              labels.push(moment.tz(values[0] * 1000, timeQuery.timeZone).format(timeQuery.labelFormat));
-            });
-          }
           responseJson.data.result.forEach((result, j) => {
             var max = Math.max(...result.values.map(values => parseFloat(values[1])));
             if(max)
@@ -363,34 +386,58 @@
           details.open = max > 0;
         });
         {% endif %}
-        colors = ['blue','pink','green','yellow','purple','orange','indigo','red','cyan','gray'];
+        colors = [{% for color in colors %}'{{ color }}',{% endfor %}];
+        var stepSeconds = timeQuery.stepMillis / 1000;
         responseJsons.forEach((responseJson, i) => {
           var hubId = requestHubIds[i];
           responseJson.data.result.forEach((result, j) => {
             var datasetsIndex = datasets.length;
             result['datasetsIndex'] = datasetsIndex;
+
+            var data = [];
+            var start = new Date(timeQuery.startDate);
+            var startSeconds = start.getTime() / 1000;
+            result.values.forEach((values, i) => {
+              var currentSeconds = values[0];
+              var nextSeconds = (currentSeconds * 1000 + timeQuery.stepMillis) / 1000;
+              if(startSeconds < currentSeconds) {
+                var catchupSeconds = startSeconds;
+                while (catchupSeconds < currentSeconds) {
+                  var nextCatchupSeconds = catchupSeconds + stepSeconds;
+                  data.push({
+                    x: moment.tz(current, timeQuery.timeZone).valueOf()
+                    , y: null
+                  });
+                  catchupSeconds = catchupSeconds + stepSeconds;
+                }
+              }
+              data.push({
+                x: moment.tz(current, timeQuery.timeZone).valueOf()
+              {% if formatBytes -%}
+                {{'  '}}, y: formatBytes(parseFloat(values[1]), max)
+              {% else -%}
+              {% if formatPercent -%}
+                {{'  '}}, y: formatPercent(values[1], 2)
+              {% else -%}
+                {{'  '}}, y: parseFloat(values[1])
+              {% endif -%}
+              {% endif -%}
+              });
+              startSeconds = currentSeconds + stepSeconds;
+            });
+
             datasets.push({
-              label: `{{ datasetLabel | default('', true) }}` //({% if resultLabel is defined %}result.metric.{{ resultLabel }} + ' in ' + {% endif %}result.metric.{{ projectPrefixLabel }} + ' in ' + (result.metric.cluster ? (result.metric.cluster + ' in ') : '') + hubId).substring(0, 90)
+              label: `{{ datasetLabel | default('', true) }}`
               , "backgroundColor": [
                 "var(--wa-color-" + colors[datasetsIndex % colors.length] + "-60)"
               ]
               , "borderColor": [
                 "color-mix(in srgb, var(--wa-color-" + colors[datasetsIndex % colors.length] + "-60) 60%, transparent)"
               ]
-              , data: result.values.map(values => {
-                return {
-                  x: moment.tz(values[0] * 1000, timeQuery.timeZone).valueOf()
-                {% if formatBytes -%}
-                  {{'  '}}, y: formatBytes(parseFloat(values[1]), max)
-                {% else -%}
-                {% if formatPercent -%}
-                  {{'  '}}, y: formatPercent(values[1], 2)
-                {% else -%}
-                  {{'  '}}, y: parseFloat(values[1])
-                {% endif -%}
-                {% endif -%}
-                };
-              })
+              {% if fill -%}
+              , fill: true
+              {% endif -%}
+              , data: data
             });
           });
         });
@@ -440,26 +487,23 @@
             var $tr = document.createElement('tr');
 
             var $iconTd = document.createElement('td');
-            var $icon = document.createElement('div');
-            $icon.setAttribute('style', 'color: ' + borderColor + '; cursor: pointer; user-select: none; font-size: 1.5em; ');
-            $icon.setAttribute('onclick', 'var chart = document.getElementById("' + panelId + '").chart; var dataset = chart.config.data.datasets[' + datasetsIndex + ']; dataset.hidden = dataset.hidden !== true; chart.update(); this.innerText = this.innerText === "▣" ? "□" : "▣"; ');
-            $icon.innerText = '▣';
+            var $icon = document.createElement('wa-checkbox');
+            $icon.checked = true;
+            $icon.setAttribute('style', '--wa-form-control-activated-color: ' + borderColor + '; --wa-form-control-border-color: ' + borderColor + '; --wa-focus-ring: var(--wa-focus-ring-style) var(--wa-focus-ring-width) ' + borderColor + '; ');
+            $icon.setAttribute('onclick', 'var chart = document.getElementById("' + panelId + '").chart; var dataset = chart.config.data.datasets[' + datasetsIndex + ']; dataset.hidden = !this.checked; chart.update(); !this.checked; ');
             $iconTd.append($icon);
             $tr.append($iconTd);
+            var $val;
 
-            var $hub = document.createElement('td');
-            $hub.innerText = hubId;
-            $tr.append($hub);
-
-            if(result.metric.cluster) {
-              var $cluster = document.createElement('td');
-              $cluster.innerText = result.metric.cluster;
-              $tr.append($cluster);
-            }
-
-            var ${{ projectPrefixLabel }} = document.createElement('td');
-            ${{ projectPrefixLabel }}.innerText = result.metric.{{ projectPrefixLabel }};
-            $tr.append(${{ projectPrefixLabel }});
+            metricLabels.forEach((metricLabel, i) => {
+              $val = document.createElement('td');
+              $tr.append($val);
+              if(metricLabel == 'hub') {
+                $val.innerText = hubId;
+              } else if(metricLabel == 'cluster' && clusterNames.length > 0 || metricLabel != 'cluster') {
+                $val.innerText = result.metric[metricLabel];
+              }
+            });
             {% if resultLabel is defined -%}
 
             var ${{ resultLabel }} = document.createElement('td');
@@ -467,7 +511,7 @@
             $tr.append(${{ resultLabel }});
             {%- endif %}
 
-            var $val = document.createElement('td');
+            $val = document.createElement('td');
             $tr.append($val);
 
             var $statsPopover = document.createElement('wa-popover');

--- a/webawesome/templates/en-us/PageLayout.htm
+++ b/webawesome/templates/en-us/PageLayout.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ SITE_LOCALE }}" class="wa-cloak wa-{{ userSiteTheme | default(SITE_THEME) }} wa-theme-{{ userWebComponentsTheme | default(WEB_COMPONENTS_THEME) }} ">
+<html lang="{{ SITE_LOCALE }}" class="wa-cloak wa-{{ userSiteTheme | default(SITE_THEME) }} wa-theme-{{ userWebComponentsTheme | default(WEB_COMPONENTS_THEME) }} wa-palette-natural wa-brand-cyan ">
   <head>
 {%- block htmHeadPageLayout %}
     <meta charset="UTF-8" />

--- a/webawesome/templates/en-us/edit/hub/HubEditPage.htm
+++ b/webawesome/templates/en-us/edit/hub/HubEditPage.htm
@@ -1,1 +1,57 @@
 {% extends "en-us/edit/hub/HubGenEditPage.htm" %}
+{% import "en-us/Chart.htm" %}
+{%- block facetChangeHubSuccess %}
+      updateDashboards();
+{% endblock facetChangeHubSuccess -%}
+{%- block htmScriptInitHubPage %}
+      updateDashboards();
+{%- endblock htmScriptInitHubPage %}
+{%- block htmBodyStartHubPage %}
+{{ super() }}
+{% if result.description is defined %}
+<p>
+  {{ result.description }}
+</p>
+{% endif %}
+{% if result is defined %}
+<wa-details open class="HtmRow" id="observability-dashboard">
+  <div slot="summary">
+    Observability dashboard for OpenShift projects
+  </div>
+  <div class="wa-stack ">
+    <div class="wa-grid ">
+      {{ dashboardCard('visualization-openshift-downtime', 'OpenShift Container Platform downtime', min=0, max=1) }}
+    </div>
+  </div>
+</wa-details>
+{% endif %}
+{%- endblock htmBodyStartHubPage %}
+
+{%- block htmScriptsHubPage %}
+      <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8/hammer.min.js"></script>
+      <script src="{{ STATIC_BASE_URL }}/js/chartjs-plugin-zoom.js"></script>
+{{ super() }}
+  <script>
+        {{ updateDashboardsFunctionStart() }}
+        Promise.all([
+            {{ dashboardPromise('visualization-openshift-downtime') }}
+            ]);
+        {{ updateDashboardsFunctionEnd() }}
+
+        {{ hubClusterProjectDashboardAsyncFunction(
+          divId='visualization-openshift-downtime'
+          , classSimpleName='Hub'
+          , legendTitle='Hubs'
+          , metricPrefix='absent(kube_node_status_condition{'
+          , metricSuffix='})'
+          , modelPrefixLabel=''
+          , modelVar='hubName'
+          , timeZone=timeZone
+          , yLabelSuffix=' downtime'
+          , datasetLabel='${hubId} downtime'
+          , fill=true
+          , colors=['red']
+        ) }}
+  </script>
+{%- endblock htmScriptsHubPage %}

--- a/webawesome/templates/en-us/edit/project/ProjectEditPage.htm
+++ b/webawesome/templates/en-us/edit/project/ProjectEditPage.htm
@@ -205,7 +205,7 @@
           , legendTitle='Projects'
           , metricPrefix='namespace:container_memory_usage_bytes:sum{'
           , metricSuffix='}'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , formatBytes=true
           , yLabelSuffix=' memory'
@@ -218,7 +218,7 @@
           , metricPrefix='namespace:container_memory_usage_bytes:sum{'
           , metricMiddle='} / on(cluster, namespace) group_left() kube_resourcequota{resource="limits.memory", type="hard", '
           , metricSuffix='}'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , tickFormat='.0%'
           , formatPercent=true
@@ -231,7 +231,7 @@
           , legendTitle='Projects'
           , metricPrefix='node_namespace_pod_container:container_cpu_usage_seconds_total:sum{'
           , metricSuffix='}'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , emptyClusterReplace='node_namespace_pod_container:container_cpu_usage_seconds_total:sum'
           , emptyClusterReplaceWith='namespace:container_cpu_usage:sum'
@@ -245,7 +245,7 @@
           , metricPrefix='node_namespace_pod_container:container_cpu_usage_seconds_total:sum{'
           , metricMiddle='} / on(cluster, namespace) group_left() kube_resourcequota{resource="limits.cpu", type="hard", '
           , metricSuffix='}'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , tickFormat='.0%'
           , formatPercent=true
@@ -257,8 +257,8 @@
           , classSimpleName='Project'
           , legendTitle='Projects'
           , metricPrefix='sum(irate(container_network_receive_bytes_total{'
-          , metricSuffix='}[10m])) by (namespace)'
-          , projectVar='projectName'
+          , metricSuffix='}[10m])) by (cluster, namespace)'
+          , modelVar='projectName'
           , timeZone=timeZone
           , formatBytes=true
           , yLabelSuffix=' received'
@@ -269,8 +269,8 @@
           , classSimpleName='Project'
           , legendTitle='Projects'
           , metricPrefix='sum(irate(container_network_transmit_bytes_total{'
-          , metricSuffix='}[10m])) by (namespace)'
-          , projectVar='projectName'
+          , metricSuffix='}[10m])) by (cluster, namespace)'
+          , modelVar='projectName'
           , timeZone=timeZone
           , formatBytes=true
           , yLabelSuffix=' transmitted'
@@ -282,10 +282,10 @@
           , legendTitle='Projects'
           , metricPrefix='sum by (cluster, exported_namespace) (DCGM_FI_DEV_GPU_UTIL{'
           , metricSuffix='} / 100)'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , tickFormat='.0%'
-          , projectPrefixLabel='exported_namespace'
+          , modelPrefixLabel='exported_namespace'
           , yLabelSuffix='% of GPU'
           , openDetailsSelector='.gpu_details'
           , datasetLabel='${result.metric.exported_namespace} in ${result.metric.cluster} in ${hubId}'
@@ -297,11 +297,11 @@
           , metricPrefix='sum by (cluster, exported_namespace) (DCGM_FI_DEV_GPU_UTIL{'
           , metricMiddle='} / 100 / on(cluster, exported_namespace) group_left() label_replace(kube_resourcequota{resource="requests.nvidia.com/gpu", type="hard", '
           , metricSuffix='}, "exported_namespace", "$1", "namespace", "(.*)"))'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , tickFormat='.0%'
-          , projectPrefixLabel='exported_namespace'
-          , projectMiddleLabel='namespace'
+          , modelPrefixLabel='exported_namespace'
+          , modelMiddleLabel='namespace'
           , yLabelSuffix='% of quota'
           , datasetLabel='${result.metric.exported_namespace} in ${result.metric.cluster} in ${hubId}'
         ) }}
@@ -309,11 +309,11 @@
           divId='visualization-project-gpu-resource-request'
           , classSimpleName='Project'
           , legendTitle='Projects'
-          , metricPrefix='count by (cluster, namespace) (kube_pod_resource_request{resource =~ ".*/gpu", '
+          , metricPrefix='sum by (cluster, namespace) (kube_pod_resource_request{resource =~ ".*/gpu", '
           , metricSuffix='})'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
-          , projectPrefixLabel='namespace'
+          , modelPrefixLabel='namespace'
           , yLabelSuffix='GPU request'
           , datasetLabel='${result.metric.namespace} in ${result.metric.cluster} in ${hubId}'
         ) }}
@@ -323,9 +323,9 @@
           , legendTitle='Projects'
           , metricPrefix='sum by (cluster, exported_namespace) (DCGM_FI_DEV_GPU_TEMP{'
           , metricSuffix='})'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
-          , projectPrefixLabel='exported_namespace'
+          , modelPrefixLabel='exported_namespace'
           , yLabelSuffix='temperature ° C'
           , datasetLabel='${result.metric.exported_namespace} in ${result.metric.cluster} in ${hubId}'
         ) }}
@@ -336,12 +336,14 @@
           , metricPrefix='rate(vllm:e2e_request_latency_seconds_sum{'
           , metricMiddle='}[10m]) / rate(vllm:e2e_request_latency_seconds_count{'
           , metricSuffix='}[10m])'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , yLabelPrefix='Latency'
           , yLabelSuffix=' (ms)'
           , openDetailsSelector='.vllm_details'
           , datasetLabel='Average (${result.metric.model_name})'
+          , metricLabels=['model_name', 'pod']
+          , displayLabels=['model', 'pod']
         ) }}
         {{ hubClusterProjectDashboardAsyncFunction(
           divId='visualization-llm-token-throughput'
@@ -350,10 +352,12 @@
           , metricPrefix='label_replace(rate(vllm:prompt_tokens_total{'
           , metricMiddle='}[10m]), "token_type", "Prompt Tokens/Sec", "namespace", "(.+)") or label_replace(rate(vllm:generation_tokens_total{'
           , metricSuffix='}[10m]), "token_type", "Generation Tokens/Sec", "namespace", "(.+)")'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , yLabelPrefix='Tokens per Second'
           , datasetLabel='${result.metric.token_type} (${result.metric.model_name})'
+          , metricLabels=['token_type', 'pod']
+          , displayLabels=['token type', 'pod']
         ) }}
         {{ hubClusterProjectDashboardAsyncFunction(
           divId='visualization-llm-ttft-latency'
@@ -362,11 +366,13 @@
           , metricPrefix='rate(vllm:time_to_first_token_seconds_sum{'
           , metricMiddle='}[10m]) / rate(vllm:time_to_first_token_seconds_count{'
           , metricSuffix='}[10m])'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , yLabelPrefix='Latency'
           , yLabelSuffix=' (ms)'
           , datasetLabel='Average TTFT (${result.metric.model_name})'
+          , metricLabels=['model_name', 'pod']
+          , displayLabels=['model', 'pod']
         ) }}
         {{ hubClusterProjectDashboardAsyncFunction(
           divId='visualization-llm-tpot-latency'
@@ -375,11 +381,13 @@
           , metricPrefix='rate(vllm:time_per_output_token_seconds_sum{'
           , metricMiddle='}[10m]) / rate(vllm:time_per_output_token_seconds_count{'
           , metricSuffix='}[10m])'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , yLabelPrefix='Latency'
           , yLabelSuffix=' (ms)'
           , datasetLabel='Mean TPOT (${result.metric.model_name})'
+          , metricLabels=['model_name', 'pod']
+          , displayLabels=['model', 'pod']
         ) }}
 
         async function queryStorageUtilization(hubId, clusterName, projectName) {

--- a/webawesome/templates/en-us/edit/tenant/TenantEditPage.htm
+++ b/webawesome/templates/en-us/edit/tenant/TenantEditPage.htm
@@ -194,7 +194,7 @@
           , legendTitle='Projects'
           , metricPrefix='namespace:container_memory_usage_bytes:sum{'
           , metricSuffix='}'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , formatBytes=true
           , datasetLabel='${result.metric.namespace} in ${result.metric.cluster} in ${hubId}'
@@ -206,7 +206,7 @@
           , legendTitle='Projects'
           , metricPrefix='node_namespace_pod_container:container_cpu_usage_seconds_total:sum{'
           , metricSuffix='}'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , emptyClusterReplace='node_namespace_pod_container:container_cpu_usage_seconds_total:sum'
           , emptyClusterReplaceWith='namespace:container_cpu_usage:sum'
@@ -221,7 +221,7 @@
           , metricPrefix='namespace:container_memory_usage_bytes:sum{'
           , metricMiddle='} / on(cluster, namespace) group_left() kube_resourcequota{resource="limits.memory", type="hard", '
           , metricSuffix='}'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , yLabelSuffix='% of quota'
           , datasetLabel='${result.metric.namespace} in ${result.metric.cluster} in ${hubId}'
@@ -234,7 +234,7 @@
           , metricPrefix='node_namespace_pod_container:container_cpu_usage_seconds_total:sum{'
           , metricMiddle='} / on(cluster, namespace) group_left() kube_resourcequota{resource="limits.cpu", type="hard", '
           , metricSuffix='}'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , yLabelSuffix='% of quota'
           , datasetLabel='${result.metric.namespace} in ${result.metric.cluster} in ${hubId}'
@@ -246,10 +246,12 @@
           , legendTitle='Projects'
           , metricPrefix='sum(DCGM_FI_DEV_GPU_UTIL{'
           , metricSuffix='}) by (cluster,exported_namespace,Hostname,modelName,UUID)'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
-          , projectPrefixLabel='exported_namespace'
+          , modelPrefixLabel='exported_namespace'
           , datasetLabel='${result.metric.exported_namespace} in ${result.metric.cluster} in ${hubId}'
+          , metricLabels=['exported_namespace', 'Hostname', 'modelName']
+          , displayLabels=['project', 'GPU node', 'GPU model']
         ) }}
         {{ hubClusterProjectDashboardAsyncFunction(
           divId='visualization-project-gpu-utilization'
@@ -258,9 +260,9 @@
           , legendTitle='Projects'
           , metricPrefix='sum(DCGM_FI_DEV_GPU_UTIL{'
           , metricSuffix='}) by (cluster,exported_namespace)'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
-          , projectPrefixLabel='exported_namespace'
+          , modelPrefixLabel='exported_namespace'
           , datasetLabel='${result.metric.exported_namespace} in ${result.metric.cluster} in ${hubId}'
         ) }}
         {{ hubClusterProjectDashboardAsyncFunction(
@@ -270,10 +272,12 @@
           , legendTitle='Projects'
           , metricPrefix='sum(DCGM_FI_DEV_MEMORY_TEMP{'
           , metricSuffix='}) by (cluster,exported_namespace,Hostname,modelName,UUID)'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
-          , projectPrefixLabel='exported_namespace'
+          , modelPrefixLabel='exported_namespace'
           , datasetLabel='${result.metric.exported_namespace} in ${result.metric.cluster} in ${hubId}'
+          , metricLabels=['exported_namespace', 'Hostname', 'modelName']
+          , displayLabels=['project', 'GPU node', 'GPU model']
         ) }}
   </script>
 {%- endblock htmScriptsTenantPage %}

--- a/webawesome/templates/en-us/search/project/ProjectSearchPage.htm
+++ b/webawesome/templates/en-us/search/project/ProjectSearchPage.htm
@@ -34,7 +34,7 @@
     </div>
   </div>
 </wa-details>
-<wa-details{% if gpuEnabled is defined and gpuEnabled %} open{% endif %} class="gpu_details " id="gpu-performance-dashboard">
+<wa-details open class="gpu_details " id="gpu-performance-dashboard">
   <div slot="summary">
     GPU Performance Metrics
   </div>
@@ -49,7 +49,7 @@
     </div>
   </div>
 </wa-details>
-<wa-details{% if vllmEnabled is defined and vllmEnabled %} open{% endif %} class="vllm_details " id="llm-performance-dashboard">
+<wa-details open class="vllm_details " id="llm-performance-dashboard">
   <div slot="summary">
     LLM Performance Metrics
   </div>
@@ -100,7 +100,7 @@
           , legendTitle='Projects'
           , metricPrefix='namespace:container_memory_usage_bytes:sum{'
           , metricSuffix='}'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , formatBytes=true
           , yLabelSuffix=' memory'
@@ -113,7 +113,7 @@
           , metricPrefix='namespace:container_memory_usage_bytes:sum{'
           , metricMiddle='} / on(cluster, namespace) group_left() kube_resourcequota{resource="limits.memory", type="hard", '
           , metricSuffix='}'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , tickFormat='.0%'
           , formatPercent=true
@@ -126,7 +126,7 @@
           , legendTitle='Projects'
           , metricPrefix='node_namespace_pod_container:container_cpu_usage_seconds_total:sum{'
           , metricSuffix='}'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , emptyClusterReplace='node_namespace_pod_container:container_cpu_usage_seconds_total:sum'
           , emptyClusterReplaceWith='namespace:container_cpu_usage:sum'
@@ -140,7 +140,7 @@
           , metricPrefix='node_namespace_pod_container:container_cpu_usage_seconds_total:sum{'
           , metricMiddle='} / on(cluster, namespace) group_left() kube_resourcequota{resource="limits.cpu", type="hard", '
           , metricSuffix='}'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , tickFormat='.0%'
           , formatPercent=true
@@ -153,7 +153,7 @@
           , legendTitle='Projects'
           , metricPrefix='sum(irate(container_network_receive_bytes_total{'
           , metricSuffix='}[10m])) by (namespace)'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , formatBytes=true
           , yLabelSuffix=' received'
@@ -165,7 +165,7 @@
           , legendTitle='Projects'
           , metricPrefix='sum(irate(container_network_transmit_bytes_total{'
           , metricSuffix='}[10m])) by (namespace)'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , formatBytes=true
           , yLabelSuffix=' transmitted'
@@ -177,12 +177,11 @@
           , legendTitle='Projects'
           , metricPrefix='sum by (cluster, exported_namespace) (DCGM_FI_DEV_GPU_UTIL{'
           , metricSuffix='} / 100)'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , tickFormat='.0%'
-          , projectPrefixLabel='exported_namespace'
+          , modelPrefixLabel='exported_namespace'
           , yLabelSuffix='% of GPU'
-          , openDetailsSelector='.gpu_details'
           , datasetLabel='${result.metric.exported_namespace} in ${result.metric.cluster} in ${hubId}'
         ) }}
         {{ hubClusterProjectDashboardAsyncFunction(
@@ -192,11 +191,11 @@
           , metricPrefix='sum by (cluster, exported_namespace) (DCGM_FI_DEV_GPU_UTIL{'
           , metricMiddle='} / 100 / on(cluster, exported_namespace) group_left() label_replace(kube_resourcequota{resource="requests.nvidia.com/gpu", type="hard", '
           , metricSuffix='}, "exported_namespace", "$1", "namespace", "(.*)"))'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , tickFormat='.0%'
-          , projectPrefixLabel='exported_namespace'
-          , projectMiddleLabel='namespace'
+          , modelPrefixLabel='exported_namespace'
+          , modelMiddleLabel='namespace'
           , yLabelSuffix='% of quota'
           , datasetLabel='${result.metric.exported_namespace} in ${result.metric.cluster} in ${hubId}'
         ) }}
@@ -204,11 +203,11 @@
           divId='visualization-project-gpu-resource-request'
           , classSimpleName='Project'
           , legendTitle='Projects'
-          , metricPrefix='count by (cluster, namespace) (kube_pod_resource_request{resource =~ ".*/gpu", '
+          , metricPrefix='sum by (cluster, namespace) (kube_pod_resource_request{resource =~ ".*/gpu", '
           , metricSuffix='})'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
-          , projectPrefixLabel='namespace'
+          , modelPrefixLabel='namespace'
           , yLabelSuffix='GPU requests'
           , datasetLabel='${result.metric.namespace} in ${result.metric.cluster} in ${hubId}'
         ) }}
@@ -218,9 +217,9 @@
           , legendTitle='Projects'
           , metricPrefix='sum by (cluster, exported_namespace) (DCGM_FI_DEV_GPU_TEMP{'
           , metricSuffix='})'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
-          , projectPrefixLabel='exported_namespace'
+          , modelPrefixLabel='exported_namespace'
           , yLabelSuffix='temperature ° C'
           , datasetLabel='${result.metric.exported_namespace} in ${result.metric.cluster} in ${hubId}'
         ) }}
@@ -231,11 +230,10 @@
           , metricPrefix='rate(vllm:e2e_request_latency_seconds_sum{'
           , metricMiddle='}[10m]) / rate(vllm:e2e_request_latency_seconds_count{'
           , metricSuffix='}[10m])'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , yLabelPrefix='Latency'
           , yLabelSuffix=' (ms)'
-          , openDetailsSelector='.vllm_details'
           , datasetLabel='Average (${result.metric.model_name})'
         ) }}
         {{ hubClusterProjectDashboardAsyncFunction(
@@ -244,7 +242,7 @@
           , legendTitle='Token Throughput'
           , metricPrefix='rate(vllm:prompt_tokens_total{'
           , metricSuffix='}[10m])'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , yLabelPrefix='Tokens per Second'
           , datasetLabel='Prompt Tokens/Sec (${result.metric.model_name})'
@@ -256,7 +254,7 @@
           , metricPrefix='rate(vllm:time_to_first_token_seconds_sum{'
           , metricMiddle='}[10m]) / rate(vllm:time_to_first_token_seconds_count{'
           , metricSuffix='}[10m])'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , yLabelPrefix='Latency'
           , yLabelSuffix=' (ms)'
@@ -269,7 +267,7 @@
           , metricPrefix='rate(vllm:time_per_output_token_seconds_sum{'
           , metricMiddle='}[10m]) / rate(vllm:time_per_output_token_seconds_count{'
           , metricSuffix='}[10m])'
-          , projectVar='projectName'
+          , modelVar='projectName'
           , timeZone=timeZone
           , yLabelPrefix='Latency'
           , yLabelSuffix=' (ms)'

--- a/webawesome/templates/en-us/search/vm/VirtualMachineSearchPage.htm
+++ b/webawesome/templates/en-us/search/vm/VirtualMachineSearchPage.htm
@@ -1,5 +1,13 @@
 {% extends "en-us/search/vm/VirtualMachineGenSearchPage.htm" %}
-{%- block htmBodyEndVirtualMachinePage %}
+{% import "en-us/Chart.htm" %}
+{%- block facetChangeVirtualMachineSuccess %}
+      updateDashboards();
+{% endblock facetChangeVirtualMachineSuccess -%}
+{%- block htmScriptInitVirtualMachinePage %}
+      updateDashboards();
+{%- endblock htmScriptInitVirtualMachinePage %}
+{%- block htmBodyStartVirtualMachinePage %}
+{{ super() }}
 {% if resultCount > 0 %}
 <wa-details open class="HtmRow" id="observability-dashboard">
   <div slot="summary">
@@ -7,108 +15,88 @@
   </div>
   <div class="wa-stack ">
     <div class="wa-grid ">
-      {{ dashboardCard('visualization-total-memory-utilization', 'VM total memory utilization') }}
-      {{ dashboardCard('visualization-total-cpu-utilization', 'VM total CPU utilization') }}
+      {{ dashboardCard('visualization-total-memory-utilization', 'VM total memory utilization', min=0) }}
+      {{ dashboardCard('visualization-total-cpu-utilization', 'VM total CPU utilization', min=0) }}
     </div>
     <div class="wa-grid ">
-      {{ dashboardCard('visualization-quota-memory-utilization', 'VM quota memory utilization') }}
-      {{ dashboardCard('visualization-quota-cpu-utilization', 'VM quota CPU utilization') }}
+      {{ dashboardCard('visualization-quota-memory-utilization', 'VM quota memory utilization', min=0) }}
+      {{ dashboardCard('visualization-quota-cpu-utilization', 'VM quota CPU utilization', min=0) }}
     </div>
   </div>
 </wa-details>
 {% endif %}
-{{ super() }}
-{%- endblock htmBodyEndVirtualMachinePage %}
-{%- block htmStyleVirtualMachinePage %}
-{%- endblock htmStyleVirtualMachinePage %}
-{%- block htmScriptInitVirtualMachinePage %}
+{%- endblock htmBodyStartVirtualMachinePage %}
 
-      var facetRangeGapVal = document.querySelector("#pageSearchVal-pageFacetRangeGap-{{ classSimpleName }}-input").value;
-      var startValue = document.querySelector("#pageSearchVal-pageFacetRangeStart-{{ classSimpleName }}-input").value;
-      var endValue = document.querySelector("#pageSearchVal-pageFacetRangeEnd-{{ classSimpleName }}-input").value;
-      var timeZone = document.querySelector("#pageFacetRangeTimeZoneInput").value;
-      var start = moment.tz(startValue, 'YYYY-MM-DDTHH:mm', timeZone).utc().toISOString();
-      var end = moment.tz(endValue, 'YYYY-MM-DDTHH:mm', timeZone).utc().toISOString();
-      var step;
-      switch (facetRangeGapVal) {
-        case "+1YEAR":
-          step = "1y";
-          break;
-        case "+1MONTH":
-          step = "1M";
-          break;
-        case "+1DAY":
-          step = "1d";
-          break;
-        case "+1HOUR":
-          step = "1h";
-          break;
-        case "+1MINUTE":
-          step = "1m";
-          break;
-        default:
-          step = "7d";
-      }
-
-      var timeQuery = {
-        start: start
-        , end: end
-        , step: step
-      };
-
-      Promise.all([
-          {{ dashboardPromise('visualization-total-memory-utilization') }}
-          , {{ dashboardPromise('visualization-total-cpu-utilization') }}
-          , {{ dashboardPromise('visualization-quota-memory-utilization') }}
-          , {{ dashboardPromise('visualization-quota-cpu-utilization') }}
-          ]);
-{%- endblock htmScriptInitVirtualMachinePage %}
 {%- block htmScriptsVirtualMachinePage %}
+      <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8/hammer.min.js"></script>
+      <script src="{{ STATIC_BASE_URL }}/js/chartjs-plugin-zoom.js"></script>
 {{ super() }}
-    <script>
-    {{ hubClusterProjectDashboardAsyncFunction(
-      divId='visualization-total-memory-utilization'
-      , yaxisTitle='Total VM memory'
-      , classSimpleName='VirtualMachine'
-      , legendTitle='virtual machines'
-      , resultLabel='name'
-      , metricPrefix='irate(kubevirt_vmi_memory_used_bytes{'
-      , metricSuffix='}[10m])'
-      , projectVar='vmProject'
-    ) }}
-    {{ hubClusterProjectDashboardAsyncFunction(
-      divId='visualization-total-cpu-utilization'
-      , yaxisTitle='Total VM memory'
-      , classSimpleName='VirtualMachine'
-      , legendTitle='virtual machines'
-      , resultLabel='name'
-      , metricPrefix='irate(kubevirt_vmi_cpu_usage_seconds_total{'
-      , metricSuffix='}[10m])'
-      , projectVar='vmProject'
-    ) }}
-    {{ hubClusterProjectDashboardAsyncFunction(
-      divId='visualization-quota-memory-utilization'
-      , yaxisTitle='Percent of VM memory usage'
-      , classSimpleName='VirtualMachine'
-      , legendTitle='virtual machines'
-      , resultLabel='name'
-      , metricPrefix='irate(kubevirt_vmi_memory_used_bytes{'
-      , metricMiddle='}[10m]) / on(cluster, namespace, name) kubevirt_vm_resource_requests{ resource="memory", unit="bytes", '
-      , metricSuffix='}'
-      , projectVar='vmProject'
-      , tickformat='.2%'
-    ) }}
-    {{ hubClusterProjectDashboardAsyncFunction(
-      divId='visualization-quota-cpu-utilization'
-      , yaxisTitle='Percent of VM CPU usage'
-      , classSimpleName='VirtualMachine'
-      , legendTitle='virtual machines'
-      , resultLabel='name'
-      , metricPrefix='irate(kubevirt_vmi_cpu_usage_seconds_total{'
-      , metricMiddle='}[10m]) / on(cluster, namespace, name) kubevirt_vm_resource_requests{ resource="cpu", unit="sockets", '
-      , metricSuffix='}'
-      , projectVar='vmProject'
-      , tickformat='.2%'
-    ) }}
-    </script>
+  <script>
+        {{ updateDashboardsFunctionStart() }}
+        Promise.all([
+            {{ dashboardPromise('visualization-total-memory-utilization') }}
+            , {{ dashboardPromise('visualization-total-cpu-utilization') }}
+            , {{ dashboardPromise('visualization-quota-memory-utilization') }}
+            , {{ dashboardPromise('visualization-quota-cpu-utilization') }}
+            ]);
+        {{ updateDashboardsFunctionEnd() }}
+
+        {{ hubClusterProjectDashboardAsyncFunction(
+          divId='visualization-total-memory-utilization'
+          , yaxisTitle='Total VM memory'
+          , classSimpleName='VirtualMachine'
+          , legendTitle='virtual machines'
+          , resultLabel='name'
+          , metricPrefix='irate(kubevirt_vmi_memory_used_bytes{'
+          , metricSuffix='}[10m])'
+          , modelVar='vmProject'
+          , timeZone=timeZone
+          , formatBytes=true
+          , yLabelSuffix=' memory'
+          , datasetLabel='${result.metric.namespace} in ${result.metric.cluster} in ${hubId}'
+        ) }}
+        {{ hubClusterProjectDashboardAsyncFunction(
+          divId='visualization-total-cpu-utilization'
+          , yaxisTitle='Total VM memory'
+          , classSimpleName='VirtualMachine'
+          , legendTitle='virtual machines'
+          , resultLabel='name'
+          , metricPrefix='irate(kubevirt_vmi_cpu_usage_seconds_total{'
+          , metricSuffix='}[10m])'
+          , modelVar='vmProject'
+        ) }}
+        {{ hubClusterProjectDashboardAsyncFunction(
+          divId='visualization-quota-memory-utilization'
+          , yaxisTitle='Percent of VM memory usage'
+          , classSimpleName='VirtualMachine'
+          , legendTitle='virtual machines'
+          , resultLabel='name'
+          , metricPrefix='irate(kubevirt_vmi_memory_used_bytes{'
+          , metricMiddle='}[10m]) / on(cluster, namespace, name) kubevirt_vm_resource_requests{ resource="memory", unit="bytes", '
+          , metricSuffix='}'
+          , modelVar='vmProject'
+          , timeZone=timeZone
+          , tickFormat='.2%'
+          , formatPercent=true
+          , yLabelSuffix='% of quota'
+          , datasetLabel='${result.metric.namespace} in ${result.metric.cluster} in ${hubId}'
+        ) }}
+        {{ hubClusterProjectDashboardAsyncFunction(
+          divId='visualization-quota-cpu-utilization'
+          , yaxisTitle='Percent of VM CPU usage'
+          , classSimpleName='VirtualMachine'
+          , legendTitle='virtual machines'
+          , resultLabel='name'
+          , metricPrefix='irate(kubevirt_vmi_cpu_usage_seconds_total{'
+          , metricMiddle='}[10m]) / on(cluster, namespace, name) kubevirt_vm_resource_requests{ resource="cpu", unit="sockets", '
+          , metricSuffix='}'
+          , modelVar='vmProject'
+          , timeZone=timeZone
+          , tickformat='.2%'
+          , formatPercent=true
+          , yLabelSuffix='% of quota'
+          , datasetLabel='${result.metric.namespace} in ${result.metric.cluster} in ${hubId}'
+        ) }}
+  </script>
 {%- endblock htmScriptsVirtualMachinePage %}


### PR DESCRIPTION
In the first implementation of Web Awesome Charts, gaps in time series data were being collapsed into one line and reporting inaccurate timestamps.

Before time series fixes: https://aitelemetry.apps.obs.nerc.mghpcc.org/en-us/edit/project/HUB-moc-CLUSTER-nerc-ocp-test-PROJECT-ai-performance-profiling?start=&rows=&facet.field=hubId&facet.field=clusterName&facet.range.start=2026-03-01T00%3A00%3A00.000[America%2FDenver]&facet.range.end=2026-04-01T00%3A00%3A00.000[America%2FDenver]&facet.range={!tag=r1}created
<img width="1086" height="670" alt="image" src="https://github.com/user-attachments/assets/6f5526c6-84bb-4b7b-8bdb-961c55346359" />

After time series fixes: https://aitelemetry-computate.apps.shift.nerc.mghpcc.org/en-us/edit/project/HUB-moc-CLUSTER-nerc-ocp-test-PROJECT-ai-performance-profiling?start=&rows=&facet.field=hubId&facet.field=clusterName&facet.range.start=2026-03-01T00%3A00%3A00.000[America%2FDenver]&facet.range.end=2026-04-01T00%3A00%3A00.000[America%2FDenver]&facet.range={!tag=r1}created
<img width="1081" height="689" alt="image" src="https://github.com/user-attachments/assets/b4b03633-8466-47fe-8a2e-bf94efd576d2" />
