### PR TITLE
Fixes charts to not go into the future and fix timezones. Add chart reporting CPU throttling on projects and tenants. 

### DIFF
--- a/webawesome/templates/en-us/Chart.htm
+++ b/webawesome/templates/en-us/Chart.htm
@@ -53,7 +53,7 @@
         var endValue = document.querySelector("#pageSearchVal-pageFacetRangeEnd-{{ classSimpleName }}-input").value;
         var timeZone = document.querySelector("#pageFacetRangeTimeZoneInput").value;
         var startDate = moment.tz(startValue, 'YYYY-MM-DDTHH:mm', timeZone).utc();
-        var endDate = moment.tz(endValue, 'YYYY-MM-DDTHH:mm', timeZone).utc();
+        var endDate = moment.min(moment.tz(endValue, 'YYYY-MM-DDTHH:mm', timeZone), moment()).utc();
         var start = startDate.toISOString();
         var end = endDate.toISOString();
         const diffInMs = Math.abs(endDate - startDate);
@@ -441,7 +441,7 @@
             });
           });
         });
-        chart.xLabel = timeQuery.startDate.format(timeQuery.labelFormat) + '–' + timeQuery.endDate.format(timeQuery.labelFormatLong) + ' in ' + timeQuery.timeZone;
+        chart.xLabel = moment.tz(timeQuery.startDate, timeQuery.timeZone).format(timeQuery.labelFormat) + '–' + moment.tz(timeQuery.endDate, timeQuery.timeZone).format(timeQuery.labelFormatLong) + ' in ' + timeQuery.timeZone;
         {% if formatBytes -%}
         chart.yLabel = '{{ yLabelPrefix }}' + formatBytesUnit(max) + '{{ yLabelSuffix }}';
         {% else -%}

--- a/webawesome/templates/en-us/edit/project/ProjectEditPage.htm
+++ b/webawesome/templates/en-us/edit/project/ProjectEditPage.htm
@@ -27,6 +27,9 @@
       {{ dashboardCard('visualization-project-cpu-bytes', 'Total project CPU usage in cluster ' ~ result.clusterName ~ ' project ' ~ result.projectName, min=0) }}
       {{ dashboardCard('visualization-quota-cpu-bytes', 'Project quota CPU usage in cluster ' ~ result.clusterName ~ ' project ' ~ result.projectName, min=0) }}
     </div>
+    <div class="wa-grid ">
+      {{ dashboardCard('visualization-pod-cpu-throttling', 'Total pod CPU throttling', min=0) }}
+    </div>
   </div>
 </wa-details>
 <wa-details open class="HtmRow" id="network-performance-dashboard">
@@ -184,6 +187,7 @@
             , {{ dashboardPromise('visualization-quota-memory-bytes') }}
             , {{ dashboardPromise('visualization-project-cpu-bytes') }}
             , {{ dashboardPromise('visualization-quota-cpu-bytes') }}
+            , {{ dashboardPromise('visualization-pod-cpu-throttling') }}
             , {{ dashboardPromise('visualization-network-receive') }}
             , {{ dashboardPromise('visualization-network-transmit') }}
             , queryStorageUtilization('{{ result.hubId }}', '{{ result.clusterName }}', '{{ result.projectName }}')
@@ -251,6 +255,19 @@
           , formatPercent=true
           , yLabelSuffix='% of quota'
           , datasetLabel='${result.metric.namespace} in ${result.metric.cluster} in ${hubId}'
+        ) }}
+        {{ hubClusterProjectDashboardAsyncFunction(
+          divId='visualization-pod-cpu-throttling'
+          , classSimpleName='Project'
+          , legendTitle='Projects'
+          , metricPrefix='sum(irate(container_cpu_cfs_throttled_periods_total{'
+          , metricSuffix='}[10m])) by (cluster, namespace, pod) > 0'
+          , modelVar='projectName'
+          , timeZone=timeZone
+          , yLabelSuffix='throttled periods'
+          , datasetLabel='${result.metric.namespace} in ${result.metric.cluster} in ${hubId}'
+          , metricLabels=['namespace', 'pod']
+          , displayLabels=['namespace', 'pod']
         ) }}
         {{ hubClusterProjectDashboardAsyncFunction(
           divId='visualization-network-receive'

--- a/webawesome/templates/en-us/edit/tenant/TenantEditPage.htm
+++ b/webawesome/templates/en-us/edit/tenant/TenantEditPage.htm
@@ -155,6 +155,9 @@
       {{ dashboardCard('visualization-quota-cpu-bytes', 'Project quota CPU usage') }}
     </div>
     <div class="wa-grid ">
+      {{ dashboardCard('visualization-pod-cpu-throttling', 'Total pod CPU throttling', min=0) }}
+    </div>
+    <div class="wa-grid ">
       {{ dashboardCard('visualization-tenant-gpu-utilization', 'GPU utilization per GPU device in tenant {{ result.tenantName }}') }}
     </div>
     <wa-card with-header>
@@ -181,6 +184,7 @@
             , {{ dashboardPromise('visualization-total-cpu-bytes') }}
             , {{ dashboardPromise('visualization-quota-memory-bytes') }}
             , {{ dashboardPromise('visualization-quota-cpu-bytes') }}
+            , {{ dashboardPromise('visualization-pod-cpu-throttling') }}
             , {{ dashboardPromise('visualization-tenant-gpu-utilization') }}
             , {{ dashboardPromise('visualization-project-gpu-utilization') }}
             , {{ dashboardPromise('visualization-tenant-gpu-temperature') }}
@@ -238,6 +242,19 @@
           , timeZone=timeZone
           , yLabelSuffix='% of quota'
           , datasetLabel='${result.metric.namespace} in ${result.metric.cluster} in ${hubId}'
+        ) }}
+        {{ hubClusterProjectDashboardAsyncFunction(
+          divId='visualization-pod-cpu-throttling'
+          , classSimpleName='Project'
+          , legendTitle='Projects'
+          , metricPrefix='sum(irate(container_cpu_cfs_throttled_periods_total{'
+          , metricSuffix='}[10m])) by (cluster, namespace) > 0'
+          , modelVar='projectName'
+          , timeZone=timeZone
+          , yLabelSuffix='throttled periods'
+          , datasetLabel='${result.metric.namespace} in ${result.metric.cluster} in ${hubId}'
+          , metricLabels=['hub', 'cluster', 'namespace']
+          , displayLabels=['hub', 'cluster', 'namespace']
         ) }}
         {{ hubClusterProjectDashboardAsyncFunction(
           divId='visualization-tenant-gpu-utilization'

--- a/webawesome/templates/en-us/search/project/ProjectSearchPage.htm
+++ b/webawesome/templates/en-us/search/project/ProjectSearchPage.htm
@@ -21,6 +21,9 @@
       {{ dashboardCard('visualization-project-cpu-bytes', 'Total project CPU usage', min=0) }}
       {{ dashboardCard('visualization-quota-cpu-bytes', 'Project quota CPU usage', min=0) }}
     </div>
+    <div class="wa-grid ">
+      {{ dashboardCard('visualization-pod-cpu-throttling', 'Total pod CPU throttling', min=0) }}
+    </div>
   </div>
 </wa-details>
 <wa-details open class="HtmRow" id="network-performance-dashboard">
@@ -81,6 +84,7 @@
             , {{ dashboardPromise('visualization-quota-memory-bytes') }}
             , {{ dashboardPromise('visualization-project-cpu-bytes') }}
             , {{ dashboardPromise('visualization-quota-cpu-bytes') }}
+            , {{ dashboardPromise('visualization-pod-cpu-throttling') }}
             , {{ dashboardPromise('visualization-network-receive') }}
             , {{ dashboardPromise('visualization-network-transmit') }}
             , {{ dashboardPromise('visualization-project-gpu-utilization') }}
@@ -146,6 +150,19 @@
           , formatPercent=true
           , yLabelSuffix='% of quota'
           , datasetLabel='${result.metric.namespace} in ${result.metric.cluster} in ${hubId}'
+        ) }}
+        {{ hubClusterProjectDashboardAsyncFunction(
+          divId='visualization-pod-cpu-throttling'
+          , classSimpleName='Project'
+          , legendTitle='Projects'
+          , metricPrefix='sum(irate(container_cpu_cfs_throttled_periods_total{'
+          , metricSuffix='}[10m])) by (cluster, namespace) > 0'
+          , modelVar='projectName'
+          , timeZone=timeZone
+          , yLabelSuffix='throttled periods'
+          , datasetLabel='${result.metric.namespace} in ${result.metric.cluster} in ${hubId}'
+          , metricLabels=['hub', 'cluster', 'namespace']
+          , displayLabels=['hub', 'cluster', 'namespace']
         ) }}
         {{ hubClusterProjectDashboardAsyncFunction(
           divId='visualization-network-receive'


### PR DESCRIPTION
The first commit fixes charts to not go into the future and fix timezones like in the chart below that reports missing ACM metrics in the future. The reason it is showing a pink bar at the end of the graph is because we are missing all metrics in the future. This PR adjusts the range end date that the user selects to end at the current date and time instead. 
<img width="594" height="629" alt="image" src="https://github.com/user-attachments/assets/0b83eafd-4234-4a66-a238-a87578cfda09" />

The second commit adds a chart for reporting CPU throttling on projects and tenants. Because deployments and statefulsets are often set to limit the CPU requests and limits on a pod, it's important to monitor the amount of CPU throttling is happening when setting the CPU limits too small.
<img width="638" height="714" alt="image" src="https://github.com/user-attachments/assets/10049ad0-09c0-45d0-a641-783927651085" />
