### PR TITLE
Fixes to Storage utilization table on project page 

### DIFF
--- a/webawesome/js/site.js
+++ b/webawesome/js/site.js
@@ -522,10 +522,10 @@ function populateDashboardDataQuery(panelId, urls, queries, timeQuery) {
 }
 
 // Convert Bytes to human readable data format
-function formatBytes(bytes) {
-  if (bytes === 0) return '0 B';
+function convertBytes(bytes) {
+  if (!bytes || bytes <= 0 || !isFinite(bytes) || isNaN(bytes)) return '0 B';
   var k = 1024;
   var sizes = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'];
-  var i = Math.floor(Math.log(bytes) / Math.log(k));
+  var i = Math.max(0, Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1));
   return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
 }

--- a/webawesome/templates/en-us/edit/project/ProjectEditPage.htm
+++ b/webawesome/templates/en-us/edit/project/ProjectEditPage.htm
@@ -392,7 +392,7 @@
 
         async function queryStorageUtilization(hubId, clusterName, projectName) {
           // Query for all PVCs with their allocated storage (shows all PVCs regardless of mount status)
-          var allocatedQuery = 'kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="' + projectName + '"}';
+          var allocatedQuery = 'kube_persistentvolumeclaim_resource_requests_storage_bytes{cluster="' + clusterName + '", namespace="' + projectName + '"}';
 
           // Query for storage used per mounted PVC
           var usedQuery = 'kubelet_volume_stats_used_bytes{cluster="' + clusterName + '", namespace="' + projectName + '"}';

--- a/webawesome/templates/en-us/edit/project/ProjectEditPage.htm
+++ b/webawesome/templates/en-us/edit/project/ProjectEditPage.htm
@@ -502,13 +502,13 @@
                   // Storage used (actual bytes used)
                   if ($usedText) {
                     var usedPercent = (totalActualUsed / quotaHard) * 100;
-                    $usedText.innerText = formatBytes(totalActualUsed) + ' / ' + formatBytes(quotaHard) + ' (' + usedPercent.toFixed(1) + '%)';
+                    $usedText.innerText = convertBytes(totalActualUsed) + ' / ' + convertBytes(quotaHard) + ' (' + usedPercent.toFixed(1) + '%)';
                   }
 
                   // Storage allocated (PVC requests)
                   if ($allocatedText) {
                     var allocatedPercent = (quotaAllocated / quotaHard) * 100;
-                    $allocatedText.innerText = formatBytes(quotaAllocated) + ' / ' + formatBytes(quotaHard) + ' (' + allocatedPercent.toFixed(1) + '%)';
+                    $allocatedText.innerText = convertBytes(quotaAllocated) + ' / ' + convertBytes(quotaHard) + ' (' + allocatedPercent.toFixed(1) + '%)';
                   }
 
                   $quotaSection.style.display = 'block';
@@ -553,12 +553,12 @@
                 $tr.append($tdStatus);
 
                 var $tdAllocated = document.createElement('td');
-                $tdAllocated.innerText = formatBytes(allocatedBytes);
+                $tdAllocated.innerText = convertBytes(allocatedBytes);
                 $tdAllocated.style.textAlign = 'right';
                 $tr.append($tdAllocated);
 
                 var $tdUsed = document.createElement('td');
-                $tdUsed.innerText = isMounted ? formatBytes(usedBytes) : '-';
+                $tdUsed.innerText = isMounted ? convertBytes(usedBytes) : '-';
                 $tdUsed.style.textAlign = 'right';
                 $tr.append($tdUsed);
 
@@ -579,8 +579,8 @@
               });
 
               var totalPercent = totalAllocated > 0 ? (totalUsed / totalAllocated * 100) : 0;
-              if ($allocatedTotal) $allocatedTotal.innerText = formatBytes(totalAllocated);
-              if ($usedTotal) $usedTotal.innerText = formatBytes(totalUsed);
+              if ($allocatedTotal) $allocatedTotal.innerText = convertBytes(totalAllocated);
+              if ($usedTotal) $usedTotal.innerText = convertBytes(totalUsed);
               if ($percentTotal) $percentTotal.innerText = totalPercent.toFixed(1) + '%';
 
               $table.style.display = 'table';


### PR DESCRIPTION
Changes:
- Chart.htm file had a function formatBytes that was overriding the formatBytes function within Site.js that was used for formatting values within the resource utilization section on project page. Renamed this function to convertBytes. Also added some checks for some edge case values.
- Because of above change, changed call to formatBytes to convertBytes in projecteditpage.htm
- Added clustername to allocated storage query